### PR TITLE
serial: rda_uart: Reset status register after interrupt

### DIFF
--- a/drivers/tty/serial/rda_uart.c
+++ b/drivers/tty/serial/rda_uart.c
@@ -882,6 +882,10 @@ static irqreturn_t rda_interrupt(int irq, void *dev_id)
 
 	rda_handle_receive(port, irqstatus);
 	rda_handle_uart_transmit(port, irqstatus);
+
+	// Poke status register to reset error conditions
+	hwp_uart->status = 0;
+
 	return IRQ_HANDLED;
 }
 


### PR DESCRIPTION
When the RX FIFO overflows, it'll appear to remain overflowing after that because the error is never cleared. This patch clears clears the status register after every interrupt so characters will continue to be received.

This will allow UART console to continue accepting input after temporary overflow such as when copy and pasting.